### PR TITLE
refact/SV-210: 로그인한 사용자 userId 전달 방식 수정

### DIFF
--- a/src/main/java/ureca/nolmung/business/diary/DiaryUseCase.java
+++ b/src/main/java/ureca/nolmung/business/diary/DiaryUseCase.java
@@ -3,11 +3,13 @@ package ureca.nolmung.business.diary;
 import ureca.nolmung.business.diary.dto.request.AddDiaryReq;
 import ureca.nolmung.business.diary.dto.request.UpdateDiaryReq;
 import ureca.nolmung.business.diary.dto.response.*;
+import ureca.nolmung.jpa.user.User;
 
 public interface DiaryUseCase {
-    AddDiaryResp addDiary(Long userId, AddDiaryReq req);
-    DiaryListResp getAllDiaries(Long userId);
+    AddDiaryResp addDiary(User user, AddDiaryReq req);
+    DiaryListResp getAllDiaries(User user);
     DiaryDetailResp getDetailDiary(Long diaryId);
-    DeleteDiaryResp deleteDiary(Long diaryId);
-    UpdateDiaryResp updateDiary(Long diaryId, UpdateDiaryReq req);
+    DiaryDetailResp getDetailMyDiary(User user, Long diaryId);
+    DeleteDiaryResp deleteDiary(User user, Long diaryId);
+    UpdateDiaryResp updateDiary(User user, Long diaryId, UpdateDiaryReq req);
 }

--- a/src/main/java/ureca/nolmung/business/diary/dto/request/AddDiaryReq.java
+++ b/src/main/java/ureca/nolmung/business/diary/dto/request/AddDiaryReq.java
@@ -3,7 +3,6 @@ package ureca.nolmung.business.diary.dto.request;
 import java.util.List;
 
 public record AddDiaryReq(
-        Long userId,
         String title,
         String content,
         List<Long> places,

--- a/src/main/java/ureca/nolmung/business/diary/dto/request/UpdateDiaryReq.java
+++ b/src/main/java/ureca/nolmung/business/diary/dto/request/UpdateDiaryReq.java
@@ -3,7 +3,6 @@ package ureca.nolmung.business.diary.dto.request;
 import java.util.List;
 
 public record UpdateDiaryReq(
-    Long userId,
     String title,
     String content,
     List<Long> dogs,

--- a/src/main/java/ureca/nolmung/business/review/ReviewService.java
+++ b/src/main/java/ureca/nolmung/business/review/ReviewService.java
@@ -22,8 +22,8 @@ public class ReviewService implements ReviewUseCase{
     @Override
     @Transactional
     public AddReviewResp addReview(User user, AddReviewReq req) {
-        User loginuser = userManager.validateUserExistence(user.getId());
-        return reviewManager.addReview(loginuser, req);
+        User loginUser = userManager.validateUserExistence(user.getId());
+        return reviewManager.addReview(loginUser, req);
     }
 
     @Transactional

--- a/src/main/java/ureca/nolmung/business/review/ReviewService.java
+++ b/src/main/java/ureca/nolmung/business/review/ReviewService.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ureca.nolmung.business.review.dto.request.AddReviewReq;
 import ureca.nolmung.business.review.dto.response.AddReviewResp;
+import ureca.nolmung.business.review.dto.response.DeleteReviewResp;
 import ureca.nolmung.implementation.review.ReviewManager;
 import ureca.nolmung.implementation.review.dtomapper.ReviewDtoMapper;
+import ureca.nolmung.implementation.user.UserManager;
 import ureca.nolmung.jpa.review.Review;
 import ureca.nolmung.jpa.user.User;
 import ureca.nolmung.persistence.user.UserRepository;
@@ -15,22 +17,18 @@ import ureca.nolmung.persistence.user.UserRepository;
 @RequiredArgsConstructor
 public class ReviewService implements ReviewUseCase{
     private final ReviewManager reviewManager;
-    private final UserRepository userRepository;
+    private final UserManager userManager;
 
     @Override
     @Transactional
-    public Long addReview(Long userId, AddReviewReq req) {
-//        User loginUser = userManager.getLoginUser(userId);
-        // 임시
-        User loginUser = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found")); // 예외 처리
-
-        return reviewManager.addReview(loginUser, req);
+    public AddReviewResp addReview(User user, AddReviewReq req) {
+        User loginuser = userManager.validateUserExistence(user.getId());
+        return reviewManager.addReview(loginuser, req);
     }
 
     @Transactional
-    public Long deleteReview(Long reviewId) {
-        reviewManager.deleteReview(reviewId);
-        return reviewId;
+    public DeleteReviewResp deleteReview(User user, Long reviewId) {
+        reviewManager.checkReviewWriter(user.getId(), reviewId);
+        return reviewManager.deleteReview(reviewId);
     }
 }

--- a/src/main/java/ureca/nolmung/business/review/ReviewUseCase.java
+++ b/src/main/java/ureca/nolmung/business/review/ReviewUseCase.java
@@ -4,9 +4,11 @@ import ureca.nolmung.business.dummy.dto.request.AddDummyReq;
 import ureca.nolmung.business.review.dto.request.AddReviewReq;
 import ureca.nolmung.business.review.dto.request.AddReviewReq;
 import ureca.nolmung.business.review.dto.response.AddReviewResp;
+import ureca.nolmung.business.review.dto.response.DeleteReviewResp;
 import ureca.nolmung.jpa.review.Review;
+import ureca.nolmung.jpa.user.User;
 
 public interface ReviewUseCase {
-    Long addReview(Long userId, AddReviewReq req);
-    Long deleteReview(Long reviewId);
+    AddReviewResp addReview(User user, AddReviewReq req);
+    DeleteReviewResp deleteReview(User user, Long reviewId);
 }

--- a/src/main/java/ureca/nolmung/business/review/dto/request/AddReviewReq.java
+++ b/src/main/java/ureca/nolmung/business/review/dto/request/AddReviewReq.java
@@ -2,7 +2,14 @@ package ureca.nolmung.business.review.dto.request;
 
 import java.util.List;
 
-public record AddReviewReq(int rating, Long placeId, String category, List<LabelDto> labels) {
-    public record LabelDto(Long labelId, String labelName) {
+public record AddReviewReq(
+    Long placeId,
+    int rating,
+    String category,
+    List<LabelDto> labels
+) {
+    public record LabelDto(
+        Long labelId,
+        String labelName) {
     }
 }

--- a/src/main/java/ureca/nolmung/business/review/dto/response/DeleteReviewResp.java
+++ b/src/main/java/ureca/nolmung/business/review/dto/response/DeleteReviewResp.java
@@ -1,4 +1,4 @@
 package ureca.nolmung.business.review.dto.response;
 
-public record AddReviewResp(Long reviewId) {
+public record DeleteReviewResp(Long reviewId) {
 }

--- a/src/main/java/ureca/nolmung/implementation/diary/DiaryExceptionType.java
+++ b/src/main/java/ureca/nolmung/implementation/diary/DiaryExceptionType.java
@@ -8,7 +8,7 @@ import ureca.nolmung.exception.Status;
 public enum DiaryExceptionType implements ExceptionType {
 
     DIARY_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "일기를 찾을 수 없습니다."),
-    DIARY_UNAUTHORIZED_EXCEPTION(Status.UNAUTHORIZED, "수정 권한이 없습니다.");
+    DIARY_UNAUTHORIZED_EXCEPTION(Status.UNAUTHORIZED, "접근 권한이 없습니다.");
 
     private final Status status;
     private final String message;

--- a/src/main/java/ureca/nolmung/implementation/diary/DiaryManager.java
+++ b/src/main/java/ureca/nolmung/implementation/diary/DiaryManager.java
@@ -173,10 +173,11 @@ public class DiaryManager {
 				.orElseThrow(() -> new DiaryException(DiaryExceptionType.DIARY_NOT_FOUND_EXCEPTION));
 	}
 
-	public void checkDiaryWriter(Long userId, Long diaryId) {
+	public Diary checkDiaryWriter(Long userId, Long diaryId) {
 		Diary diary = diaryRepository.findById(diaryId).orElseThrow(() -> new DiaryException(DiaryExceptionType.DIARY_NOT_FOUND_EXCEPTION));
 		if (!diary.getUser().getId().equals(userId)) {
 			throw new DiaryException(DiaryExceptionType.DIARY_UNAUTHORIZED_EXCEPTION);
 		}
+		return diary;
 	}
 }

--- a/src/main/java/ureca/nolmung/implementation/review/ReviewExceptionType.java
+++ b/src/main/java/ureca/nolmung/implementation/review/ReviewExceptionType.java
@@ -7,7 +7,8 @@ import ureca.nolmung.exception.Status;
 @AllArgsConstructor
 public enum ReviewExceptionType implements ExceptionType {
 
-    REVIEW_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "해당 리뷰가 존재하지 않습니다.");
+    REVIEW_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "해당 리뷰가 존재하지 않습니다."),
+    REVIEW_UNAUTHORIZED_EXCEPTION(Status.UNAUTHORIZED, "접근 권한이 없습니다.");
 
     private final Status status;
     private final String message;

--- a/src/main/java/ureca/nolmung/implementation/review/dtomapper/ReviewDtoMapper.java
+++ b/src/main/java/ureca/nolmung/implementation/review/dtomapper/ReviewDtoMapper.java
@@ -10,7 +10,4 @@ import java.util.stream.Collectors;
 
 @Component
 public class ReviewDtoMapper {
-    public AddReviewResp toAddReviewResp(Review newReview) {
-        return new AddReviewResp( "성공적으로 " + newReview.getId() + "번 후기가 등록되었습니다.");
-    }
 }

--- a/src/main/java/ureca/nolmung/presentation/controller/diary/DiaryController.java
+++ b/src/main/java/ureca/nolmung/presentation/controller/diary/DiaryController.java
@@ -3,11 +3,13 @@ package ureca.nolmung.presentation.controller.diary;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ureca.nolmung.business.diary.DiaryUseCase;
 import ureca.nolmung.business.diary.dto.request.AddDiaryReq;
 import ureca.nolmung.business.diary.dto.request.UpdateDiaryReq;
 import ureca.nolmung.business.diary.dto.response.*;
+import ureca.nolmung.business.user.dto.response.CustomUserDetails;
 import ureca.nolmung.config.response.ResponseDto;
 import ureca.nolmung.config.response.ResponseUtil;
 
@@ -21,31 +23,37 @@ public class DiaryController {
 
     @Operation(summary = "일기 등록")
     @PostMapping("")
-    public ResponseDto<AddDiaryResp> addDiary(@RequestBody AddDiaryReq req) {
-        return ResponseUtil.SUCCESS("일기 생성에 성공하였습니다.", diaryUseCase.addDiary(req.userId(), req));
+    public ResponseDto<AddDiaryResp> addDiary(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AddDiaryReq req) {
+        return ResponseUtil.SUCCESS("일기 생성에 성공하였습니다.", diaryUseCase.addDiary(userDetails.getUser(), req));
     }
 
     @Operation(summary = "일기 목록 조회")
     @GetMapping("")
-    public ResponseDto<DiaryListResp> getAllDiaries(@RequestParam Long userId) {
-        return ResponseUtil.SUCCESS("일기 조회에 성공하였습니다.", diaryUseCase.getAllDiaries(userId));
+    public ResponseDto<DiaryListResp> getAllDiaries(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseUtil.SUCCESS("일기 조회에 성공하였습니다.", diaryUseCase.getAllDiaries(userDetails.getUser()));
     }
 
-    @Operation(summary = "일기 상세 조회")
-    @GetMapping("/{diaryId}")
+    @Operation(summary = "일기 상세 조회(모든 유저용)")
+    @GetMapping("/public/{diaryId}")
     public ResponseDto<DiaryDetailResp> getDetailDiary(@PathVariable Long diaryId) {
         return ResponseUtil.SUCCESS("일기 상세조회에 성공하였습니다.", diaryUseCase.getDetailDiary(diaryId));
     }
 
+    @Operation(summary = "일기 상세 조회(개인)")
+    @GetMapping("/private/{diaryId}")
+    public ResponseDto<DiaryDetailResp> getDetailMyDiary(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long diaryId) {
+        return ResponseUtil.SUCCESS("일기 상세조회에 성공하였습니다.", diaryUseCase.getDetailMyDiary(userDetails.getUser(), diaryId));
+    }
+
     @Operation(summary = "일기 삭제")
     @DeleteMapping("/{diaryId}")
-    public ResponseDto<DeleteDiaryResp> deleteDiary(@PathVariable Long diaryId) {
-        return ResponseUtil.SUCCESS("일기 삭제에 성공하였습니다.", diaryUseCase.deleteDiary(diaryId));
+    public ResponseDto<DeleteDiaryResp> deleteDiary(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long diaryId) {
+        return ResponseUtil.SUCCESS("일기 삭제에 성공하였습니다.", diaryUseCase.deleteDiary(userDetails.getUser(), diaryId));
     }
 
     @Operation(summary = "일기 수정")
     @PatchMapping("/{diaryId}")
-    public ResponseDto<UpdateDiaryResp> updateDiary(@PathVariable Long diaryId, @RequestBody UpdateDiaryReq req) {
-        return ResponseUtil.SUCCESS("일기 수정에 성공하였습니다.", diaryUseCase.updateDiary(diaryId, req));
+    public ResponseDto<UpdateDiaryResp> updateDiary(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long diaryId, @RequestBody UpdateDiaryReq req) {
+        return ResponseUtil.SUCCESS("일기 수정에 성공하였습니다.", diaryUseCase.updateDiary(userDetails.getUser(), diaryId, req));
     }
 }

--- a/src/main/java/ureca/nolmung/presentation/controller/review/ReviewController.java
+++ b/src/main/java/ureca/nolmung/presentation/controller/review/ReviewController.java
@@ -3,10 +3,13 @@ package ureca.nolmung.presentation.controller.review;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ureca.nolmung.business.review.ReviewUseCase;
 import ureca.nolmung.business.review.dto.request.AddReviewReq;
 import ureca.nolmung.business.review.dto.response.AddReviewResp;
+import ureca.nolmung.business.review.dto.response.DeleteReviewResp;
+import ureca.nolmung.business.user.dto.response.CustomUserDetails;
 import ureca.nolmung.config.response.ResponseDto;
 import ureca.nolmung.config.response.ResponseUtil;
 
@@ -20,15 +23,13 @@ public class ReviewController {
 
     @Operation(summary = "후기 등록")
     @PostMapping("")
-    public ResponseDto<Long> addReview(Long userId, @RequestBody AddReviewReq req) {
-        Long createReviewId = reviewUseCase.addReview(userId, req);
-        return ResponseUtil.SUCCESS("후기 생성에 성공하였습니다.",createReviewId);
+    public ResponseDto<AddReviewResp> addReview(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody AddReviewReq req) {
+        return ResponseUtil.SUCCESS("후기 생성에 성공하였습니다.",reviewUseCase.addReview(userDetails.getUser(), req));
     }
 
     @Operation(summary = "후기 삭제")
     @DeleteMapping("/{reviewId}")
-    public ResponseDto<Long> deleteReview(@PathVariable Long reviewId) {
-        Long deleteReviewId = reviewUseCase.deleteReview(reviewId);
-        return ResponseUtil.SUCCESS("후기 삭제에 성공하였습니다.", deleteReviewId);
+    public ResponseDto<DeleteReviewResp> deleteReview(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long reviewId) {
+        return ResponseUtil.SUCCESS("후기 삭제에 성공하였습니다.", reviewUseCase.deleteReview(userDetails.getUser(), reviewId));
     }
 }


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- https://ureca7.atlassian.net/browse/SV-210
- 

> ## 💻 작업 내용
- 후기 시스템 / 다이어리 시스템 : 로그인한 사용자 @AuthenticationPrincipal 로 인증 방식 변경
- 전체적인 코드 리팩토링 수정 (불필요한 메소드나 중복 메소드 간소화)
---
> ## 🙇 특이 사항
- 다이어리 상세 조회시 두가지 방식으로 조회되어야 해서 일단 구분해둠.
-  1. /api/v1/diary/public/{diaryId} (지도 리뷰 -> 모든 유저 열람 가능) : 사용자 인증 X
-  2./api/v1/diary/private/{diaryId} (오늘멍 목록 -> 상세조회) : 사용자 인증 O
---
> ## 👻 리뷰 요구사항 (선택)
- 해당 방식은 멘토링때 추가로 질문해보겠습니다.
---
