### PR TITLE
feat/sv-245: 추천 목록 배치 트리거 구현

### DIFF
--- a/src/main/java/ureca/nolmung/business/bookmark/BookmarkService.java
+++ b/src/main/java/ureca/nolmung/business/bookmark/BookmarkService.java
@@ -31,7 +31,6 @@ public class BookmarkService implements BookmarkUseCase {
 	private final UserManager userManager;
 	private final PlaceRepository placeRepository;
 	private final BookmarkRepository bookmarkRepository;
-	private final UserRepository userRepository;
 
 	@Transactional
 	@Override

--- a/src/main/java/ureca/nolmung/business/bookmark/BookmarkService.java
+++ b/src/main/java/ureca/nolmung/business/bookmark/BookmarkService.java
@@ -19,6 +19,7 @@ import ureca.nolmung.jpa.place.Place;
 import ureca.nolmung.jpa.user.User;
 import ureca.nolmung.persistence.bookmark.BookmarkRepository;
 import ureca.nolmung.persistence.place.PlaceRepository;
+import ureca.nolmung.persistence.user.UserRepository;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -28,13 +29,17 @@ public class BookmarkService implements BookmarkUseCase {
 	private final BookmarkManager bookmarkManager;
 	private final PlaceRepository placeRepository;
 	private final BookmarkRepository bookmarkRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
 	@Override
 	public Long createBookmark(User user, BookmarkServiceRequest serviceRequest) {
 		Place place = placeRepository.findById(serviceRequest.getPlaceId())
 			.orElseThrow(() -> new PlaceException(PlaceExceptionType.PLACE_NOT_FOUND_EXCEPTION));
+		//TODO place와 user의 북마크 카운트를 한 번에 조정하는 메서드를 매니저에 만들어두는게 어떨까
 		place.addBookmarkCount();
+		user.addBookmarkCount();
+		userRepository.save(user);
 		return bookmarkManager.save(serviceRequest.toEntity(user, place));
 	}
 
@@ -45,6 +50,9 @@ public class BookmarkService implements BookmarkUseCase {
 			.orElseThrow(() -> new BookmarkException(BookmarkExceptionType.BOOKMARK_NOT_FOUND_EXCEPTION));
 
 		bookmarkManager.delete(bookmark, user);
+		user.subtractBookmarkCount();
+		userRepository.save(user);
+
 		return bookmarkId;
 	}
 

--- a/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
+++ b/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
@@ -2,7 +2,6 @@ package ureca.nolmung.business.recommend;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.personalizeruntime.model.PredictedItem;
@@ -10,26 +9,29 @@ import ureca.nolmung.business.recommend.dto.response.RecommendResp;
 import ureca.nolmung.implementation.dog.DogManager;
 import ureca.nolmung.implementation.recommend.AwsPersonalizeManager;
 import ureca.nolmung.implementation.recommend.RecommendManager;
+import ureca.nolmung.implementation.recommend.RedisManager;
 import ureca.nolmung.implementation.recommend.dtomapper.RecommendDtoMapper;
 import ureca.nolmung.jpa.dog.Dog;
 import ureca.nolmung.jpa.place.Place;
 import ureca.nolmung.jpa.user.User;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class RecommendService implements RecommendUseCase{
+public class RecommendService implements RecommendUseCase {
     private final AwsPersonalizeManager awsPersonalizeManager;
     private final RecommendManager recommendManager;
     private final DogManager dogManager;
     private final RecommendDtoMapper recommendDtoMapper;
-    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
+    private final RedisManager redisManager;
 
     @Override
     @Transactional(readOnly = true)
     public List<RecommendResp> getMostBookmarkedPlaces() {
+        log.info("좋아요 수 기반 추천");
         List<Place> places = recommendManager.getMostBookmarkedPlaces();
         return recommendDtoMapper.toGetPlaceRecommendations(places);
     }
@@ -37,40 +39,37 @@ public class RecommendService implements RecommendUseCase{
     @Override
     @Transactional(readOnly = true)
     public List<RecommendResp> getPlaceRecommendationsForDogs(User user) {
+        log.info("반려견 크기 기반 추천");
         List<Dog> dogs = dogManager.getDogList(user.getId());
         List<Place> places = recommendManager.getPlaceRecommendationsForDogs(dogs);
+        //TODO 랜덤하게 5개 뽑는 부분 추가
         return recommendDtoMapper.toGetPlaceRecommendations(places);
     }
 
     @Override
     @Transactional(readOnly = true)
     public List<RecommendResp> getPlaceRecommendationsNearByUser(User user) {
+        log.info("근처 추천");
         List<Place> nearByPlaces = recommendManager.findNearbyPlaces(user.getUserLatitude(), user.getUserLongitude());
-        List<Place> randomSelectNearByPlaces = recommendManager.randomSelectPlaces(nearByPlaces);
+        List<Place> randomSelectNearByPlaces = recommendManager.randomSelectPlaces(nearByPlaces, 5);
         return recommendDtoMapper.toGetPlaceRecommendations(randomSelectNearByPlaces);
     }
 
     @Override
     public List<RecommendResp> getPlaceRecommendationsFromPersonalize(User user) {
+        String key = String.valueOf(user.getId());
+        Long ttl = redisManager.getExpire(key, TimeUnit.SECONDS);
 
-        Boolean isKeyExists = redisTemplate.hasKey(String.valueOf(user.getId()));
-
-        if (isKeyExists) {
-            List<RecommendResp> recommendResps = awsPersonalizeManager.getRedis(user.getId());
-            return awsPersonalizeManager.getRandomRecommendResps(recommendResps, 5);
-        } else {
-            List<PredictedItem> awsRecs = awsPersonalizeManager.getRecs(user.getId());
-            List<Place> places = awsPersonalizeManager.getPlaces(awsRecs);
-            List<RecommendResp> recommendResps = awsPersonalizeManager.saveRedis(places, user.getId());
+        if (ttl != null && ttl > 600) {
+            log.info("레디스에 있습니다");
+            redisManager.addExpire(key, 48, TimeUnit.HOURS);
+            List<RecommendResp> recommendResps = redisManager.getRedis(user.getId());
             return awsPersonalizeManager.getRandomRecommendResps(recommendResps, 5);
         }
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<RecommendResp> getPlaceRecommendationsFromPersonalizeForBatch(Long userId) {
-        List<PredictedItem> awsRecs = awsPersonalizeManager.getRecs(userId);
+        log.info("레디스에 없습니다");
+        List<PredictedItem> awsRecs = awsPersonalizeManager.getRecs(user.getId());
         List<Place> places = awsPersonalizeManager.getPlaces(awsRecs);
-        return recommendDtoMapper.toGetPlaceRecommendations(places);
+        List<RecommendResp> recommendResps = redisManager.saveRedis(places, key);
+        return awsPersonalizeManager.getRandomRecommendResps(recommendResps, 5);
     }
 }

--- a/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
+++ b/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
@@ -25,7 +25,7 @@ public class RecommendService implements RecommendUseCase{
     private final RecommendManager recommendManager;
     private final DogManager dogManager;
     private final RecommendDtoMapper recommendDtoMapper;
-    private final RedisTemplate<String, List<Place>> redisTemplate;
+    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
 
     @Override
     @Transactional(readOnly = true)

--- a/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
+++ b/src/main/java/ureca/nolmung/business/recommend/RecommendService.java
@@ -42,8 +42,8 @@ public class RecommendService implements RecommendUseCase {
         log.info("반려견 크기 기반 추천");
         List<Dog> dogs = dogManager.getDogList(user.getId());
         List<Place> places = recommendManager.getPlaceRecommendationsForDogs(dogs);
-        //TODO 랜덤하게 5개 뽑는 부분 추가
-        return recommendDtoMapper.toGetPlaceRecommendations(places);
+        List<Place> randomSelectNearByPlaces = recommendManager.randomSelectPlaces(places, 5);
+        return recommendDtoMapper.toGetPlaceRecommendations(randomSelectNearByPlaces);
     }
 
     @Override

--- a/src/main/java/ureca/nolmung/business/recommend/RecommendUseCase.java
+++ b/src/main/java/ureca/nolmung/business/recommend/RecommendUseCase.java
@@ -10,5 +10,4 @@ public interface RecommendUseCase {
     List<RecommendResp> getPlaceRecommendationsForDogs(User user);
     List<RecommendResp> getPlaceRecommendationsNearByUser(User user);
     List<RecommendResp> getPlaceRecommendationsFromPersonalize(User user);
-    List<RecommendResp> getPlaceRecommendationsFromPersonalizeForBatch(Long userId);
 }

--- a/src/main/java/ureca/nolmung/implementation/recommend/AwsPersonalizeManager.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/AwsPersonalizeManager.java
@@ -2,7 +2,6 @@ package ureca.nolmung.implementation.recommend;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.personalizeruntime.PersonalizeRuntimeClient;
@@ -28,7 +27,6 @@ public class AwsPersonalizeManager {
     private final String campaignArn;
     private final PersonalizeRuntimeClient personalizeRuntimeClient;
     private final PlaceRepository placeRepository;
-    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
     private static final int DEFAULT_NUM_RESULTS = 25;
 
     public List<PredictedItem> getRecs(Long userId) {
@@ -63,34 +61,11 @@ public class AwsPersonalizeManager {
         return places;
     }
 
-    public List<RecommendResp> saveRedis(List<Place> places, Long userId) {
-        List<RecommendResp> recommendResponses = places.stream()
-                .map(place -> new RecommendResp(
-                        place.getId(),
-                        place.getName(),
-                        place.getCategory(),
-                        place.getRoadAddress(),
-                        place.getAddress(),
-                        place.getPlaceImageUrl(),
-                        place.getRatingAvg(),
-                        place.getRatingCount()
-                ))
-                .collect(Collectors.toList());
-
-        redisTemplate.opsForValue().set(String.valueOf(userId), recommendResponses);
-
-        return recommendResponses;
-    }
-
     public List<RecommendResp> getRandomRecommendResps(List<RecommendResp> recommendResps, int count) {
         if (count >= recommendResps.size()) {
             return recommendResps;
         }
         Collections.shuffle(recommendResps);
         return recommendResps.subList(0, count);
-    }
-
-    public List<RecommendResp> getRedis(Long userId) {
-        return redisTemplate.opsForValue().get(String.valueOf(userId));
     }
 }

--- a/src/main/java/ureca/nolmung/implementation/recommend/AwsPersonalizeManager.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/AwsPersonalizeManager.java
@@ -29,7 +29,7 @@ public class AwsPersonalizeManager {
     private final PersonalizeRuntimeClient personalizeRuntimeClient;
     private final PlaceRepository placeRepository;
     private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
-    private static final int DEFAULT_NUM_RESULTS = 25; // 기본값 설정
+    private static final int DEFAULT_NUM_RESULTS = 25;
 
     public List<PredictedItem> getRecs(Long userId) {
 

--- a/src/main/java/ureca/nolmung/implementation/recommend/RecommendManager.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/RecommendManager.java
@@ -59,12 +59,12 @@ public class RecommendManager {
     }
 
 
-    public List<Place> randomSelectPlaces(List<Place> nearbyPlaces) {
-        if (nearbyPlaces.size() <= 5) {
+    public List<Place> randomSelectPlaces(List<Place> nearbyPlaces, int count) {
+        if (nearbyPlaces.size() <= count) {
             return nearbyPlaces;
         }
         Collections.shuffle(nearbyPlaces);
 
-        return nearbyPlaces.subList(0, 5);
+        return nearbyPlaces.subList(0, count);
     }
 }

--- a/src/main/java/ureca/nolmung/implementation/recommend/RecommendManager.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/RecommendManager.java
@@ -24,7 +24,7 @@ public class RecommendManager {
     private final PlacePositionRepository placePositionRepository;
 
     private final int SRID = 4326;
-    private static final double radius = 5.0;
+    private static final double RADIUS = 5.0;
     private final GeometryFactory geometryFactory = new GeometryFactory();
     public List<Place> getMostBookmarkedPlaces() {
         return placeRepository.findTopNPlaces(PageRequest.of(0, 5));
@@ -39,7 +39,7 @@ public class RecommendManager {
     }
 
     public List<Place> findNearbyPlaces(double userLatitude, double userLongitude) {
-        Polygon polygon = generateCirclePolygon(userLatitude, userLongitude, radius);
+        Polygon polygon = generateCirclePolygon(userLatitude, userLongitude, RADIUS);
         return placePositionRepository.findPlaceByCoordinate(polygon);
     }
 

--- a/src/main/java/ureca/nolmung/implementation/recommend/RedisManager.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/RedisManager.java
@@ -1,0 +1,54 @@
+package ureca.nolmung.implementation.recommend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import ureca.nolmung.business.recommend.dto.response.RecommendResp;
+import ureca.nolmung.jpa.place.Place;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RedisManager {
+
+    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
+
+    public Long getExpire(String key, TimeUnit timeUnit) {
+        return redisTemplate.getExpire(key, timeUnit);
+    }
+
+    public void addExpire(String key, int hour, TimeUnit timeUnit) {
+        redisTemplate.expire(key, hour, timeUnit);
+    }
+
+    public void boundValueOps(String key, List<RecommendResp> recommendResps, int hour, TimeUnit timeUnit) {
+        redisTemplate.boundValueOps(key)
+                .set(recommendResps, hour, timeUnit);
+    }
+
+    public List<RecommendResp> getRedis(Long userId) {
+        return redisTemplate.opsForValue().get(String.valueOf(userId));
+    }
+
+    public List<RecommendResp> saveRedis(List<Place> places, String key) {
+        List<RecommendResp> recommendResponses = places.stream()
+                .map(place -> new RecommendResp(
+                        place.getId(),
+                        place.getName(),
+                        place.getCategory(),
+                        place.getRoadAddress(),
+                        place.getAddress(),
+                        place.getPlaceImageUrl(),
+                        place.getRatingAvg(),
+                        place.getRatingCount()
+                ))
+                .collect(Collectors.toList());
+
+        boundValueOps(key, recommendResponses, 48, TimeUnit.HOURS);
+
+        return recommendResponses;
+    }
+}

--- a/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchConfig.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchConfig.java
@@ -44,7 +44,8 @@ public class BatchConfig {
     private final AwsPersonalizeManager awsPersonalizeManager;
     private final RedisManager redisManager;
     private final RecommendDtoMapper recommendDtoMapper;
-    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
+
+    private static final int TIME_TO_LIVE = 48;
 
     @Bean
     public Job saveRecommendationsJob() {
@@ -98,7 +99,7 @@ public class BatchConfig {
             Long userId = entry.getKey();
             List<RecommendResp> recommendResps = entry.getValue();
 
-            redisManager.boundValueOps(String.valueOf(userId), recommendResps, 48, TimeUnit.HOURS);
+            redisManager.boundValueOps(String.valueOf(userId), recommendResps, TIME_TO_LIVE, TimeUnit.HOURS);
 
             userManager.updateBookmarkCount(userId);
         });

--- a/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchConfig.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchConfig.java
@@ -37,7 +37,7 @@ public class BatchConfig {
     private final PlatformTransactionManager platformTransactionManager;
     private final DataSource dataSource;
     private final RecommendUseCase recommendUseCase;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, List<RecommendResp>> redisTemplate;
 
     @Bean
     public Job saveRecommendationsJob() {

--- a/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchScheduler.java
+++ b/src/main/java/ureca/nolmung/implementation/recommend/batch/BatchScheduler.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j

--- a/src/main/java/ureca/nolmung/implementation/user/UserExceptionType.java
+++ b/src/main/java/ureca/nolmung/implementation/user/UserExceptionType.java
@@ -7,7 +7,9 @@ import ureca.nolmung.exception.Status;
 @AllArgsConstructor
 public enum UserExceptionType implements ExceptionType {
 
-    USER_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "회원이 존재하지 않습니다.");
+    USER_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "회원이 존재하지 않습니다."),
+    BOOKMARK_COUNT_CANNOT_BE_NEGATIVE(Status.BAD_REQUEST, "북마크 수는 음수가 될 수 없습니다.");
+
 
     private final Status status;
     private final String message;

--- a/src/main/java/ureca/nolmung/implementation/user/UserManager.java
+++ b/src/main/java/ureca/nolmung/implementation/user/UserManager.java
@@ -63,4 +63,14 @@ public class UserManager {
 
         userBookmarkRepository.save(userBookmark);
     }
+
+    public void addBookmarkCount(User user) {
+        user.addBookmarkCount();
+        userRepository.save(user);
+    }
+
+    public void subtractBookmarkCount(User user) {
+        user.subtractBookmarkCount();
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/ureca/nolmung/implementation/user/UserManager.java
+++ b/src/main/java/ureca/nolmung/implementation/user/UserManager.java
@@ -6,7 +6,9 @@ import lombok.RequiredArgsConstructor;
 import ureca.nolmung.business.user.dto.request.UserReq;
 import ureca.nolmung.jpa.user.Enum.Provider;
 import ureca.nolmung.jpa.user.User;
+import ureca.nolmung.jpa.userbookmark.UserBookmark;
 import ureca.nolmung.persistence.user.UserRepository;
+import ureca.nolmung.persistence.userbookmark.UserBookmarkRepository;
 
 import java.util.Optional;
 
@@ -15,6 +17,7 @@ import java.util.Optional;
 public class UserManager {
 
     private final UserRepository userRepository;
+    private final UserBookmarkRepository userBookmarkRepository;
 
     // 사용자 유효성 검증 메서드
     public User validateUserExistence(Long userId) {
@@ -45,5 +48,19 @@ public class UserManager {
         user.setSocialLoginInfo(name, profileImageUrl, email, provider);
 
         return userRepository.save(user);
+    }
+
+    public void updateBookmarkCount(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserExceptionType.USER_NOT_FOUND_EXCEPTION));
+
+        int userBookmarkCount = user.getBookmarkCount();
+
+        UserBookmark userBookmark = userBookmarkRepository.findById(userId)
+                .orElseGet(() -> UserBookmark.createUserBookmark(userId, userBookmarkCount));
+
+        userBookmark.updateBookmarkCount(userBookmarkCount);
+
+        userBookmarkRepository.save(userBookmark);
     }
 }

--- a/src/main/java/ureca/nolmung/jpa/user/User.java
+++ b/src/main/java/ureca/nolmung/jpa/user/User.java
@@ -133,10 +133,9 @@ public class User extends BaseEntity {
     }
 
     public void subtractBookmarkCount() {
-        if (this.bookmarkCount > 0) {
-            this.bookmarkCount--;
-        } else {
+        if (this.bookmarkCount <= 0) {
             throw new UserException(UserExceptionType.BOOKMARK_COUNT_CANNOT_BE_NEGATIVE);
         }
+        this.bookmarkCount--;
     }
 }

--- a/src/main/java/ureca/nolmung/jpa/user/User.java
+++ b/src/main/java/ureca/nolmung/jpa/user/User.java
@@ -17,6 +17,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ureca.nolmung.business.user.dto.request.UserReq;
+import ureca.nolmung.implementation.user.UserException;
+import ureca.nolmung.implementation.user.UserExceptionType;
 import ureca.nolmung.jpa.config.BaseEntity;
 import ureca.nolmung.jpa.diary.Diary;
 import ureca.nolmung.jpa.user.Enum.Gender;
@@ -80,6 +82,8 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private Long diaryCount = 0L;
 
+    @Column(nullable = false, name = "bookmark_count")
+    private int bookmarkCount;
 
     public void singUp(UserReq req)
     {
@@ -121,6 +125,18 @@ public class User extends BaseEntity {
         if(this.diaryCount > 0)
         {
             this.diaryCount--;
+        }
+    }
+
+    public void addBookmarkCount() {
+        this.bookmarkCount++;
+    }
+
+    public void subtractBookmarkCount() {
+        if (this.bookmarkCount > 0) {
+            this.bookmarkCount--;
+        } else {
+            throw new UserException(UserExceptionType.BOOKMARK_COUNT_CANNOT_BE_NEGATIVE);
         }
     }
 }

--- a/src/main/java/ureca/nolmung/jpa/userbookmark/UserBookmark.java
+++ b/src/main/java/ureca/nolmung/jpa/userbookmark/UserBookmark.java
@@ -1,0 +1,26 @@
+package ureca.nolmung.jpa.userbookmark;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class UserBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_bookmark_id")
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "bookmark_count")
+    private int bookmarkCount;
+}

--- a/src/main/java/ureca/nolmung/jpa/userbookmark/UserBookmark.java
+++ b/src/main/java/ureca/nolmung/jpa/userbookmark/UserBookmark.java
@@ -18,9 +18,20 @@ public class UserBookmark {
     @Column(name = "user_bookmark_id")
     private Long id;
 
-    @Column(name = "user_id")
+    @Column(nullable = false, name = "user_id")
     private Long userId;
 
-    @Column(name = "bookmark_count")
+    @Column(nullable = false, name = "bookmark_count")
     private int bookmarkCount;
+
+    public static UserBookmark createUserBookmark(Long userId, int userBookmarkCount) {
+        UserBookmark userBookmark = new UserBookmark();
+        userBookmark.userId = userId;
+        userBookmark.bookmarkCount = userBookmarkCount;
+        return userBookmark;
+    }
+
+    public void updateBookmarkCount(int userBookmarkCount) {
+        this.bookmarkCount = userBookmarkCount;
+    }
 }

--- a/src/main/java/ureca/nolmung/persistence/place/PlaceRepository.java
+++ b/src/main/java/ureca/nolmung/persistence/place/PlaceRepository.java
@@ -18,11 +18,4 @@ public interface PlaceRepository extends JpaRepository<Place, Long>, PlaceReposi
 
 	@Query("SELECT p FROM Place p ORDER BY p.bookmarkCount DESC")
 	List<Place> findTopNPlaces(PageRequest pageRequest);
-
-	@Query(value = "SELECT * FROM place p " +
-			"WHERE p.address LIKE CONCAT('%', :addressProvince, '%') " +
-			"ORDER BY RAND() " +
-			"LIMIT 5", nativeQuery = true)
-	List<Place> findByUserAddress(@Param("addressProvince")String AddressProvince);
-
 }

--- a/src/main/java/ureca/nolmung/persistence/place/PlaceRepositoryImpl.java
+++ b/src/main/java/ureca/nolmung/persistence/place/PlaceRepositoryImpl.java
@@ -53,8 +53,6 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
 
 		return queryFactory.selectFrom(place)
 			.where(builder)
-			.orderBy(Expressions.numberTemplate(Double.class, "function('rand')").asc())
-			.limit(5)
 			.fetch();
 	}
 

--- a/src/main/java/ureca/nolmung/persistence/userbookmark/UserBookmarkRepository.java
+++ b/src/main/java/ureca/nolmung/persistence/userbookmark/UserBookmarkRepository.java
@@ -1,0 +1,8 @@
+package ureca.nolmung.persistence.userbookmark;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ureca.nolmung.jpa.userbookmark.UserBookmark;
+
+public interface UserBookmarkRepository extends JpaRepository<UserBookmark, Long> {
+
+}


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- https://ureca7.atlassian.net/browse/SV-245

> ## 💻 작업 내용
- 사용자에 대한 장소 추천 목록을 매일 배치하는 것에서 사용자가 누른 즐겨찾기 수를 비교해보고 10이상 차이난다면 추천 목록을 갱신 배치하는 것으로 변경
- 사용자가 장소에대한 즐겨찾기를 생성하거나 삭제할 때 사용자의 즐겨찾기 수 또한 변하게 수정
- 사용자 엔티티에 북마크카운트 컬럼 추가하여 즐겨찾기 수 기록
- 배치시 비교를 위한 유저북마크 테이블 추가
---
> ## 🙇 특이 사항
-  Redis TTL 설정을 해둬야하나 고민했는데 이 부분은 내일 멘토링때 질문드려보고 결정하면 좋을 것 같습니다.
---
> ## 👻 리뷰 요구사항 (선택)
- 북마크서비스에 즐겨찾기를 생성하거나 삭제할 때 장소엔티티의 즐겨찾기 수와 유저 엔티티의 즐겨찾기 수를 모두 직접 조정하는데 이 부분은 매니저에서 하는 것이 맞지 않을까 생각되는데 어떻게 생각하시는지 궁금합니다!
---
