### PR TITLE
refact/SV-319: 오늘멍 상세조회시 응답값에 작성자 아이디 값 추가

### DIFF
--- a/src/main/java/ureca/nolmung/business/diary/dto/response/DiaryDetailResp.java
+++ b/src/main/java/ureca/nolmung/business/diary/dto/response/DiaryDetailResp.java
@@ -3,6 +3,7 @@ package ureca.nolmung.business.diary.dto.response;
 import java.util.List;
 
 public record DiaryDetailResp(
+        Long userId,
         Long diaryId,
         String title,
         String content,

--- a/src/main/java/ureca/nolmung/implementation/diary/dtomapper/DiaryDtoMapper.java
+++ b/src/main/java/ureca/nolmung/implementation/diary/dtomapper/DiaryDtoMapper.java
@@ -72,6 +72,7 @@ public class DiaryDtoMapper {
                 .collect(Collectors.toList());
 
         return new DiaryDetailResp(
+                diary.getUser().getId(),
                 diary.getId(),
                 diary.getTitle(),
                 diary.getContent(),


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- https://ureca7.atlassian.net/browse/SV-319

> ## 💻 작업 내용
- 오늘멍 상세조회시 응답값에 작성자 아이디 값 추가
- 본인이 작성한 오늘멍인지 판별하고 수정/삭제 기능 제한
---
> ## 🙇 특이 사항
-
---
> ## 👻 리뷰 요구사항 (선택)
-
---
