### PR TITLE
refact/SV-332: 오늘멍 목록 조회시 모든 미디어 반환하도록 수정

### DIFF
--- a/src/main/java/ureca/nolmung/business/diary/dto/response/DiaryListResp.java
+++ b/src/main/java/ureca/nolmung/business/diary/dto/response/DiaryListResp.java
@@ -1,5 +1,7 @@
 package ureca.nolmung.business.diary.dto.response;
 
+import ureca.nolmung.jpa.media.Enum.MediaType;
+
 import java.util.List;
 
 public record DiaryListResp(User user,List<Diary> diaries) {
@@ -15,6 +17,12 @@ public record DiaryListResp(User user,List<Diary> diaries) {
             String content,
             Boolean publicYn,
             String createdAt,
+            List<Media> mediaList
+    ) {}
+
+    public record Media(
+            Long mediaId,
+            MediaType mediaType,
             String mediaUrl
     ) {}
 }

--- a/src/main/java/ureca/nolmung/implementation/diary/dtomapper/DiaryDtoMapper.java
+++ b/src/main/java/ureca/nolmung/implementation/diary/dtomapper/DiaryDtoMapper.java
@@ -31,15 +31,20 @@ public class DiaryDtoMapper {
 
     private DiaryListResp.Diary mapDiaryToDiaryListResp(Diary diary) {
         String formattedDate = diary.getCreatedAt().format(DATE_FORMATTER);
-        String mediaUrl = diary.getMediaList().isEmpty() ? "" : diary.getMediaList().get(0).getMediaUrl();
-
+        List<DiaryListResp.Media> mediaList = diary.getMediaList().stream()
+                .map(media -> new DiaryListResp.Media(
+                        media.getId(),
+                        media.getMediaType(),
+                        media.getMediaUrl()
+                ))
+                .collect(Collectors.toList());
         return new DiaryListResp.Diary(
                 diary.getId(),
                 diary.getTitle(),
                 diary.getContent(),
                 diary.isPublicYn(),
                 formattedDate,
-                mediaUrl
+                mediaList
         );
     }
 

--- a/src/main/java/ureca/nolmung/persistence/diary/DiaryRepository.java
+++ b/src/main/java/ureca/nolmung/persistence/diary/DiaryRepository.java
@@ -20,7 +20,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
             "JOIN FETCH d.user u " +
             "LEFT JOIN FETCH d.mediaList m " +
             "WHERE d.user.id = :userId " +
-            "AND (m.mediaType = 'IMAGE' OR m IS NULL) " +
             "ORDER BY d.createdAt DESC")
     List<Diary> findDiariesWithFirstMediaByUser(@Param("userId") Long userId);
 


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- https://ureca7.atlassian.net/browse/SV-332

> ## 💻 작업 내용
- 오늘멍 목록 조회시 미디어 타입 지정으로 인해 빈배열로 반환되는 이슈
- 오늘멍에 대해 모든 미디어 반환하도록 수정
---
> ## 🙇 특이 사항
-
---
> ## 👻 리뷰 요구사항 (선택)
-
---
