### PR TITLE
feat/SV-380 : 반려견 프로필 관련 예외처리 추가 및 커스텀 도메인 CORS 허용

### DIFF
--- a/src/main/java/ureca/nolmung/business/dog/DogService.java
+++ b/src/main/java/ureca/nolmung/business/dog/DogService.java
@@ -44,6 +44,7 @@ public class DogService implements DogUseCase{
     public DogResp deleteDog(Long userId, Long dogId) {
         // 반려견 프로필 삭제
         Dog currentDog = dogManager.validateDogExistence(userId, dogId);
+        dogManager.checkDogDeletionLimit(userId);
         dogManager.deleteDog(dogId);
         return dogDtoMapper.toDogResp(currentDog);
     }

--- a/src/main/java/ureca/nolmung/config/security/SecurityConfig.java
+++ b/src/main/java/ureca/nolmung/config/security/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
 				@Override
 				public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
 					CorsConfiguration config = new CorsConfiguration();
-					config.setAllowedOrigins(Arrays.asList("http://localhost:8080", "https://api.nolmung.org", "http://localhost:3000", "https://dev.nolmung.org", "https://nolmung.org", "https://nolmung.netlify.app/", "https://nolmung-official.netlify.app/", "https://initially-game-chamois.ngrok-free.app/", "https://d2ce-115-161-21-211.ngrok-free.app/")); //리소스를 허용할 URL 지정
+					config.setAllowedOrigins(Arrays.asList("http://localhost:8080", "https://api.nolmung.org", "http://localhost:3000", "https://dev.nolmung.org", "https://nolmung.org", "https://nolmung.netlify.app/", "https://nolmung-official.netlify.app/", "https://initially-game-chamois.ngrok-free.app/", "https://d2ce-115-161-21-211.ngrok-free.app/", "https://nolmung-official.com/")); //리소스를 허용할 URL 지정
 					config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); //허용하는 HTTP METHOD 지정
 					config.setAllowCredentials(true); // 인증, 인가를 위한 credentials 를 TRUE로 설정 - TRUE로 설정 시, setAllowedOrigins에 "*" 설정 불가
 					config.setAllowedHeaders(Arrays.asList("Authorization", "Authorization-refresh", "Cache-Control", "Content-Type", "X-Api-Key"));

--- a/src/main/java/ureca/nolmung/implementation/dog/DogExceptionType.java
+++ b/src/main/java/ureca/nolmung/implementation/dog/DogExceptionType.java
@@ -8,7 +8,8 @@ import ureca.nolmung.exception.Status;
 public enum DogExceptionType implements ExceptionType {
 
     DOG_NOT_FOUND_EXCEPTION(Status.NOT_FOUND, "반려견을 찾을 수 없습니다."),
-    DOG_REGISTRATION_LIMIT_EXCEEDED(Status.BAD_REQUEST, "등록 가능한 반려견 수를 초과하였습니다.");
+    DOG_REGISTRATION_LIMIT_EXCEEDED(Status.BAD_REQUEST, "등록 가능한 반려견 수를 초과하였습니다."),
+    DOG_MIN_PROFILE_NOT_EMPTY(Status.BAD_REQUEST, "최소 한 마리의 반려견 프로필은 남겨두셔야 합니다.");
 
 
     private final Status status;

--- a/src/main/java/ureca/nolmung/implementation/dog/DogManager.java
+++ b/src/main/java/ureca/nolmung/implementation/dog/DogManager.java
@@ -66,4 +66,12 @@ public class DogManager {
             throw new DogException(DogExceptionType.DOG_REGISTRATION_LIMIT_EXCEEDED);
         }
     }
+
+    public void checkDogDeletionLimit(Long userId) {
+
+        // 현재 등록된 반려견 프로필 개수를 확인하여, 반려견 프로필 삭제 가능한 상태인지 판단 (등록된 프로필 개수가 최소 1개는 있어야 함)
+        if (dogRepository.countByUserId(userId) <= 1) {
+            throw new DogException(DogExceptionType.DOG_MIN_PROFILE_NOT_EMPTY);
+        }
+    }
 }


### PR DESCRIPTION
> ## 📝 관련 이슈
---
- https://ureca7.atlassian.net/browse/SV-380

> ## 💻 작업 내용
- 반려견 프로필 관련 예외처리 : 반려견 프로필 1개 등록되어있는 상태에서는 삭제 못하도록 예외처리 추가
- 커스텀 도메인(https://nolmung-official.com/) CORS 허용
---
> ## 🙇 특이 사항
-
---
> ## 👻 리뷰 요구사항 (선택)
-
---
